### PR TITLE
feat: group Chai.js packages

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: FSFAP
+# SPDX-FileCopyrightText: Copyright (c) 2024 Rifa Achrinza
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 2
+max_line_length = 80

--- a/shared-configs/renovate/base.json
+++ b/shared-configs/renovate/base.json
@@ -70,6 +70,13 @@
       ]
     },
     {
+      "groupName": "Chai.js packages",
+      "matchPackageNames": [
+        "chai",
+        "chai-as-promised"
+      ]
+    },
+    {
       "matchPackageNames": ["renovate"],
       "extends": ["schedule:earlyMondays"]
     }


### PR DESCRIPTION
`chai-as-promised` has a peer dependency on `chai`, of which gets a major update
together. This causes renovate to encounter "conflicting peer dependency" error.

see: https://github.com/loopbackio/loopback-connector/pull/467?notification_referrer_id=NT_kwDOAX-5-7M4OTA5ODQxOTcyOjI1MTQ3ODk5#issuecomment-1871690795
see: https://github.com/loopbackio/loopback-connector/pull/553
Signed-off-by: Rifa Achrinza <25147899+achrinza@users.noreply.github.com>
